### PR TITLE
feat: Add env parameter for BotInstance

### DIFF
--- a/src/instance/BotInstance.ts
+++ b/src/instance/BotInstance.ts
@@ -9,13 +9,16 @@ export abstract class BotInstance {
 
     private readonly execArgv: string[];
 
+    private readonly env: NodeJS.ProcessEnv;
+
     public readonly clusters: Map<number, ClusterProcess> = new Map();
 
     protected _shuttingDown = false;
 
-    protected constructor(entryPoint: string, execArgv?: string[]) {
+    protected constructor(entryPoint: string, execArgv?: string[], env?: NodeJS.ProcessEnv) {
         this.entryPoint = entryPoint;
         this.execArgv = execArgv ?? [];
+        this.env = env ?? {};
     }
 
     protected readonly eventMap: BotInstanceEventListeners = {
@@ -44,6 +47,7 @@ export abstract class BotInstance {
         try {
             const childProcess = fork(this.entryPoint, {
                 env: {
+                    ...this.env,
                     INSTANCE_ID: instanceID.toString(),
                     CLUSTER_ID: clusterID.toString(),
                     SHARD_LIST: shardList.join(','),

--- a/src/instance/ManagedInstance.ts
+++ b/src/instance/ManagedInstance.ts
@@ -26,8 +26,8 @@ export class ManagedInstance extends BotInstance {
 
     private dev: boolean = false;
 
-    constructor(entryPoint: string, host: string, port: number, instanceID: number, data: unknown, execArgv?: string[], dev?: boolean) {
-        super(entryPoint, execArgv);
+    constructor(entryPoint: string, host: string, port: number, instanceID: number, data: unknown, execArgv?: string[], env?: NodeJS.ProcessEnv, dev?: boolean) {
+        super(entryPoint, execArgv, env);
 
         this.host = host;
         this.port = port;

--- a/src/instance/StandaloneInstance.ts
+++ b/src/instance/StandaloneInstance.ts
@@ -10,8 +10,8 @@ export class StandaloneInstance extends BotInstance {
     public readonly token: string;
     public readonly intents: GatewayIntentsString[];
 
-    constructor(entryPoint: string, shardsPerCluster: number, totalClusters: number, token: string, intents: GatewayIntentsString[], execArgv?: string[]) {
-        super(entryPoint, execArgv);
+    constructor(entryPoint: string, shardsPerCluster: number, totalClusters: number, token: string, intents: GatewayIntentsString[], execArgv?: string[], env?: NodeJS.ProcessEnv) {
+        super(entryPoint, execArgv, env);
         this.shardsPerCluster = shardsPerCluster;
         this.totalClusters = totalClusters;
         this.token = token;

--- a/test/machine.ts
+++ b/test/machine.ts
@@ -13,6 +13,7 @@ const machine = new ManagedInstance(
     key: "value",
   },
   ["--import", "tsx"],
+  process.env,
   false,
 );
 


### PR DESCRIPTION
### Changes
This PR resolves #20 by adding an `env` parameter to the `BotInstance` constructor, allowing custom environment variables to be passed to the cluster processes.

The change has been propagated to both `StandaloneInstance` and `ManagedInstance`.

### Breaking change note
This change modifies the constructor signature of `ManagedInstance`. Existing implementations that depend on argument order may break. To prevent this in the future, the constructor could be migrated to a single options object pattern instead of positional arguments.